### PR TITLE
Upversion actions/checkout to v3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout code
-      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2
+      uses: actions/checkout@v3
       with:
         repository: ${{ inputs.MDM_CONFIG_REPO }}
 


### PR DESCRIPTION
At the moment in time, the following Github actions in fleetdm/fleet have `save-state` deprecation warnings, [which Github will eventually disable](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). These actions are using `fleetdm/fleet-mdm-gitops` - which currently uses v2 of `actions/checkout`.

This PR upversions `actions/checkout` to v3, which should fix the deprecation warnings. They will need updating after this PR gets merged to clear the warning on their next run.

* https://github.com/fleetdm/fleet/actions/runs/5060998214 (example-workflow.yaml)
* https://github.com/fleetdm/fleet/actions/runs/5092588002 (fleetctl-workstations.yml)
* https://github.com/fleetdm/fleet/actions/runs/5126292002 (fleetctl-workstations-canary.yml)

(there may be more, but these are the first ones I found)