### PR TITLE
Use MDM_CONFIG_DIRECTORY from inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ runs:
       run: |
         profiles=""
 
-        for file in mdm_profiles/*.mobileconfig; do
+        for file in ${{ inputs.MDM_CONFIG_DIRECTORY }}/*.mobileconfig; do
           envsubst < "$file" > "${file}.new"
           mv "${file}.new" "$file"
           profiles+=$'          - '$file$'\n'


### PR DESCRIPTION
Previously this value seemed to be hardcoded and the input ignored.