### PR TITLE
Stub out GitHub action for working with best practice config (no fleetctl changes)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,37 +53,36 @@ runs:
     - name: Run fleetctl apply
       run: |
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-        # I think all this will go away:
+        # STEP 1: Apply .controls.yml files:
+        # (Note that .controls.yml must be applied BEFORE .settings.yml to avoid resetting certain config to the defaults)
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-        # profiles=""
-
-        # for file in ${{ inputs.MDM_CONFIG_DIRECTORY }}/*.mobileconfig; do
-        #   envsubst < "$file" > "${file}.new"
-        #   mv "${file}.new" "$file"
-        #   profiles+=$'          - '$file$'\n'
-        # done
-
-        # echo "apiVersion: v1
-        # kind: team
-        # spec:
-        #   team:
-        #     name: ${{ inputs.FLEET_TEAM_NAME }}
-        #     mdm:
-        #       macos_updates:
-        #         minimum_version: \"${{ inputs.MAC_OS_MIN_VERSION }}\"
-        #         deadline: ${{ inputs.MAC_OS_VERSION_DEADLINE }}
-        #       macos_settings:
-        #         enable_disk_encryption: ${{ inputs.MAC_OS_ENABLE_DISK_ENCRYPTION }}
-        #         custom_settings:
-        # $profiles
-        # " > team-workstations-config.yml
-        # fleetctl apply -f team-workstations-config.yml
+        # TODO: Apply no-team.controls.yml
+        # TODO: Loop through folders in /teams and apply <folder-name>.controls.yml for each
 
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-        # (If we can add --force to fleetctl apply...)
+        # STEP 2: Apply .settings.yml files:
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        # TODO: Apply default.settings.yml
+        # TODO: Loop through folders in /teams and apply <folder-name>.settings.yml for each
 
-        # .controls.yml must be applied BEFORE .settings.yml to avoid resetting some config to the defaults
-        # TODO: At top-level and in each team folder, apply .controls.yml
+        # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        # STEP 3: Apply queries
+        # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        # TODO: Compile all queries into a single YAML document
+        # TODO: - Add contents of default.queries.yml
+        # TODO: - Loop through folders in /teams and add the contents of <folder-name>.queries.yml for each
+        # TODO: Apply compiled queries YAML with `--force` (deletes any queries in Fleet that aren't present in this config)
+
+        # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        # STEP 4: Apply policies
+        # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        # TODO: Compile all policies into a single YAML document
+        # TODO: - Add contents of default.policies.yml
+        # TODO: - Loop through folders in /teams and add the contents of <folder-name>.policies.yml for each
+        # TODO: Apply compiled policies YAML with `--force` (deletes any policies in Fleet that aren't present in this config)
+
+        # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        # All done!
+        # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -8,31 +8,6 @@ inputs:
   FLEET_URL:
     description: 'Fleet URL'
     required: true
-  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  # I think all this will go away:
-  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  # FLEET_TEAM_NAME:
-  #   description: 'Fleet team name to apply MDM configuration profiles to'
-  #   required: true
-  #   default: "Workstations"
-  # MDM_CONFIG_REPO: 
-  #   description: 'Repository containing MDM configuration profiles'
-  #   required: true
-  #   default: 'fleetdm/fleet'
-  # MDM_CONFIG_DIRECTORY:
-  #   description: 'Directory in repo where MDM configuration files are stored'
-  #   required: true
-  #   default: 'mdm_profiles'
-  # MAC_OS_MIN_VERSION:
-  #   description: 'Minimum macOS version of hosts'
-  #   required: true
-  # MAC_OS_VERSION_DEADLINE:
-  #   description: 'Deadline for macOS version'
-  #   required: true
-  # MAC_OS_ENABLE_DISK_ENCRYPTION: 
-  #   description: 'Enable disk encryption'
-  #   required: true
-  #   default: 'true'
 
 runs:
   using: 'composite'
@@ -56,30 +31,96 @@ runs:
         # STEP 1: Apply .controls.yml files:
         # (Note that .controls.yml must be applied BEFORE .settings.yml to avoid resetting certain config to the defaults)
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-        # TODO: Apply no-team.controls.yml
-        # TODO: Loop through folders in /teams and apply <folder-name>.controls.yml for each
+        # Apply no-team.controls.yml
+        # TODO
+
+        # Loop through folders in /teams and apply <folder-name>.controls.yml for each
+        # TODO 
 
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         # STEP 2: Apply .settings.yml files:
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-        # TODO: Apply default.settings.yml
-        # TODO: Loop through folders in /teams and apply <folder-name>.settings.yml for each
+        # Apply default.settings.yml
+        # TODO 
+
+        # Loop through folders in /teams and apply <folder-name>.settings.yml for each
+        # TODO
 
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-        # STEP 3: Apply queries
+        # STEP 3: Map team names to their IDs
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-        # TODO: Compile all queries into a single YAML document
-        # TODO: - Add contents of default.queries.yml
-        # TODO: - Loop through folders in /teams and add the contents of <folder-name>.queries.yml for each
-        # TODO: Apply compiled queries YAML with `--force` (deletes any queries in Fleet that aren't present in this config)
+        # Print a YAML document of all teams & their IDs with `fleetctl get teams --yaml`
+        # This will be used to get team IDs based on the team names in the team query & policy config files.
+        # TODO
 
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-        # STEP 4: Apply policies
+        # STEP 4: Apply queries
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-        # TODO: Compile all policies into a single YAML document
-        # TODO: - Add contents of default.policies.yml
-        # TODO: - Loop through folders in /teams and add the contents of <folder-name>.policies.yml for each
-        # TODO: Apply compiled policies YAML with `--force` (deletes any policies in Fleet that aren't present in this config)
+        # Print a YAML document of existing top-level queries with `fleetctl get queries --yaml`
+        # TODO
+
+        # Compare contents of printed queries YAML with contents of default.queries.yaml
+        # TODO 
+
+        # For each query that exists in Fleet that is **not present** in default.queries.yaml, make a cURL request to delete the query
+        # TODO 
+
+        # Apply default.queries.yaml
+        # TODO
+
+
+        # Loop through folders in /teams
+        # For each team:
+
+        # • Get a reference to the team ID from the team YAML we printed previously, based on the `team` key of the first item in <folder-name>.queries.yml
+        # TODO
+
+        # • Print a YAML document of existing queries with `fleetctl get queries --team=<team_id> --yaml` 
+        # TODO
+
+        # • Compare contents of printed team queries YAML with contents of <folder-name>.queries.yaml
+        # TODO
+
+        # • For each team query that exists in Fleet that is **not present** in <folder-name>.queries.yaml, make a cURL request to delete the query
+        # TODO
+
+        # • Apply <team-name>.queries.yaml
+        # TODO
+
+
+        # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        # STEP 5: Apply policies
+        # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        # Make a cURL request to the "List policies" endpoint: GET /api/v1/fleet/global/policies
+        # (Note that there is no `fleetctl get policies` command, so we need to make an API request here)
+
+        # Compare policies in API response with contents of default.policies.yaml
+        # TODO 
+
+        # For each policy that exists in Fleet that is **not present** in default.policies.yaml, build a list of policy IDs to delete and make a cURL request to delete those policies
+        # TODO 
+
+        # Apply default.policies.yaml
+        # TODO
+
+
+        # Loop through folders in /teams
+        # For each team:
+
+        # • Get a reference to the team ID from the team YAML we printed previously, based on the `team` key of the first item in <folder-name>.policies.yml
+        # TODO
+
+        # • # Make a cURL request to the "List team policies" endpoint: GET /api/v1/fleet/teams/{id}/policies
+        # TODO
+
+        # • Compare policies in API response with contents of <folder-name>.policies.yaml
+        # TODO
+
+        # • For each team policy that exists in Fleet that is **not present** in <folder-name>.policies.yaml, build a list of policy IDs to delete and make a cURL request to delete those policies
+        # TODO
+
+        # • Apply <team-name>.policies.yaml
+        # TODO
 
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         # All done!

--- a/action.yml
+++ b/action.yml
@@ -8,28 +8,31 @@ inputs:
   FLEET_URL:
     description: 'Fleet URL'
     required: true
-  FLEET_TEAM_NAME:
-    description: 'Fleet team name to apply MDM configuration profiles to'
-    required: true
-    default: "Workstations"
-  MDM_CONFIG_REPO: 
-    description: 'Repository containing MDM configuration profiles'
-    required: true
-    default: 'fleetdm/fleet'
-  MDM_CONFIG_DIRECTORY:
-    description: 'Directory in repo where MDM configuration files are stored'
-    required: true
-    default: 'mdm_profiles'
-  MAC_OS_MIN_VERSION:
-    description: 'Minimum macOS version of hosts'
-    required: true
-  MAC_OS_VERSION_DEADLINE:
-    description: 'Deadline for macOS version'
-    required: true
-  MAC_OS_ENABLE_DISK_ENCRYPTION: 
-    description: 'Enable disk encryption'
-    required: true
-    default: 'true'
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  # I think all this will go away:
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  # FLEET_TEAM_NAME:
+  #   description: 'Fleet team name to apply MDM configuration profiles to'
+  #   required: true
+  #   default: "Workstations"
+  # MDM_CONFIG_REPO: 
+  #   description: 'Repository containing MDM configuration profiles'
+  #   required: true
+  #   default: 'fleetdm/fleet'
+  # MDM_CONFIG_DIRECTORY:
+  #   description: 'Directory in repo where MDM configuration files are stored'
+  #   required: true
+  #   default: 'mdm_profiles'
+  # MAC_OS_MIN_VERSION:
+  #   description: 'Minimum macOS version of hosts'
+  #   required: true
+  # MAC_OS_VERSION_DEADLINE:
+  #   description: 'Deadline for macOS version'
+  #   required: true
+  # MAC_OS_ENABLE_DISK_ENCRYPTION: 
+  #   description: 'Enable disk encryption'
+  #   required: true
+  #   default: 'true'
 
 runs:
   using: 'composite'
@@ -49,27 +52,38 @@ runs:
 
     - name: Run fleetctl apply
       run: |
-        profiles=""
+        # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        # I think all this will go away:
+        # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        # profiles=""
 
-        for file in ${{ inputs.MDM_CONFIG_DIRECTORY }}/*.mobileconfig; do
-          envsubst < "$file" > "${file}.new"
-          mv "${file}.new" "$file"
-          profiles+=$'          - '$file$'\n'
-        done
+        # for file in ${{ inputs.MDM_CONFIG_DIRECTORY }}/*.mobileconfig; do
+        #   envsubst < "$file" > "${file}.new"
+        #   mv "${file}.new" "$file"
+        #   profiles+=$'          - '$file$'\n'
+        # done
 
-        echo "apiVersion: v1
-        kind: team
-        spec:
-          team:
-            name: ${{ inputs.FLEET_TEAM_NAME }}
-            mdm:
-              macos_updates:
-                minimum_version: \"${{ inputs.MAC_OS_MIN_VERSION }}\"
-                deadline: ${{ inputs.MAC_OS_VERSION_DEADLINE }}
-              macos_settings:
-                enable_disk_encryption: ${{ inputs.MAC_OS_ENABLE_DISK_ENCRYPTION }}
-                custom_settings:
-        $profiles
-        " > team-workstations-config.yml
-        fleetctl apply -f team-workstations-config.yml
+        # echo "apiVersion: v1
+        # kind: team
+        # spec:
+        #   team:
+        #     name: ${{ inputs.FLEET_TEAM_NAME }}
+        #     mdm:
+        #       macos_updates:
+        #         minimum_version: \"${{ inputs.MAC_OS_MIN_VERSION }}\"
+        #         deadline: ${{ inputs.MAC_OS_VERSION_DEADLINE }}
+        #       macos_settings:
+        #         enable_disk_encryption: ${{ inputs.MAC_OS_ENABLE_DISK_ENCRYPTION }}
+        #         custom_settings:
+        # $profiles
+        # " > team-workstations-config.yml
+        # fleetctl apply -f team-workstations-config.yml
+
+        # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        # (If we can add --force to fleetctl apply...)
+        # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+        # .controls.yml must be applied BEFORE .settings.yml to avoid resetting some config to the defaults
+        # TODO: At top-level and in each team folder, apply .controls.yml
+
       shell: bash


### PR DESCRIPTION
This is one option for how we could approach working with the existing best practice Fleet config.
This version requires no changes to `fleetctl`, but is more complicated to build for a couple of reasons:
1. `fleetctl apply` doesn't delete policies or queries; we need to accomplish this by diffing the existing queries/policies with what's present in the config
2. There is no `fleetctl get policies` command, so we need to make an API request to list policies instead of relying on fleetctl